### PR TITLE
move TrigTools ctor from Begin to Init

### DIFF
--- a/Root/Superflow.cxx
+++ b/Root/Superflow.cxx
@@ -275,10 +275,6 @@ namespace sflow {
 
         //string period = "Moriond";
         //bool useReweightUtils = false;
-
-        // -------------- Configure SusyNtuple Trigger Tool [BEGIN] --------------- //
-        m_nttrig = new TriggerTools(m_input_chain, true);
-        // -------------- Configure SusyNtuple Trigger Tool [BEGIN] --------------- //
     } // end Superflow::Begin()
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -291,6 +287,7 @@ namespace sflow {
         cout << app_name << "Superflow::Init" << endl;
         SusyNtAna::Init(tree);
 
+        m_nttrig = new TriggerTools(m_input_chain, m_dbg);
         TString input_sample = m_input_chain->GetFile()->Get("inputContainerName")->GetTitle();
         TString output_sample = m_input_chain->GetFile()->Get("outputContainerName")->GetTitle();
         TString nt_tag = m_input_chain->GetFile()->Get("productionTag")->GetTitle();

--- a/Root/Superflow.cxx
+++ b/Root/Superflow.cxx
@@ -33,7 +33,6 @@ namespace sflow {
         /////////////////////////
         // SusyNtuple/Trigger 
         /////////////////////////
-        m_nttrig = nullptr;
 
         m_CutStore_Name_Exists = false;
         m_CutStoreUntitled     = 1;
@@ -179,8 +178,6 @@ namespace sflow {
         //sl_->tools = this;
         sl_->tools = &m_nttools; // from SusyNtAna
 
-        sl_->ntTrig = m_nttrig;
-
         sl_->anaType = m_nttools.getAnaType();
 
         sl_->nt = &nt; // SusyNt
@@ -286,8 +283,7 @@ namespace sflow {
     {
         cout << app_name << "Superflow::Init" << endl;
         SusyNtAna::Init(tree);
-
-        m_nttrig = new TriggerTools(m_input_chain, m_dbg);
+        
         TString input_sample = m_input_chain->GetFile()->Get("inputContainerName")->GetTitle();
         TString output_sample = m_input_chain->GetFile()->Get("outputContainerName")->GetTitle();
         TString nt_tag = m_input_chain->GetFile()->Get("productionTag")->GetTitle();

--- a/Root/Superlink.cxx
+++ b/Root/Superlink.cxx
@@ -15,8 +15,6 @@ namespace sflow {
 
         tools = nullptr;
 
-        ntTrig = nullptr;
-
         anaType = Susy::AnalysisType::Ana_2Lep;
 
         nt = nullptr;
@@ -50,8 +48,6 @@ namespace sflow {
         isData = false;
 
         tools = nullptr;
-
-        ntTrig = nullptr;
 
         anaType = Susy::AnalysisType::Ana_2Lep;
 

--- a/Superflow/Superflow.h
+++ b/Superflow/Superflow.h
@@ -93,8 +93,6 @@ namespace sflow {
         string app_name;
         void attach_superlink(Superlink* sl_);
         
-        TriggerTools* m_nttrig;
-        
         MCWeighter* m_mcWeighter; ///< tool to determine the normalization
 
         bool computeWeights(

--- a/Superflow/Superlink.h
+++ b/Superflow/Superlink.h
@@ -29,8 +29,6 @@ namespace sflow {
         
         SusyNtTools* tools;
 
-        TriggerTools* ntTrig;
-
         AnalysisType anaType;
 
         Susy::SusyNtObject* nt;


### PR DESCRIPTION
The pointer to the tree/chain is not yet available within Begin.
It is within Init.
The previous initialization only works when the Selector is
instatiated with 'new' (although I don't fully understand why the
initialization order is different in that case).

In principle `TChain::GetFile` should always provide a valid `TFile*`
(opening the first file if necessary), but I still see some failures...to
be further investigated.
